### PR TITLE
Allow specifying XMPP server name (STARTTLS)

### DIFF
--- a/check_tls_certificate_expiration
+++ b/check_tls_certificate_expiration
@@ -18,7 +18,7 @@
 
 use strict;
 use warnings;
-use Getopt::Long;
+use Getopt::Long qw(:config auto_help);
 use Date::Calc qw(Delta_Days Parse_Date Today);
 use Crypt::OpenSSL::X509;
 
@@ -36,6 +36,12 @@ our $ARG_STARTTLS = '';
 # Argument for file check
 our $ARG_FILE = '';
 our $ARG_COMMON_NAME = '';
+
+=head1 NAME
+
+check_tls_certificate_expiration - check if a TLS certificate is about to expire
+
+=cut
 
 main();
 
@@ -87,7 +93,58 @@ sub decideExitCode {
 	}
 }
 
+=head1 SYNOPSIS
+
+check_tls_certificate_expiration --address ADDRESS|--file FILE [--port PORT] [--hostname SNI_HOSTNAME] [--common-name NAME] [--warn DAYS] [--crit DAYS] [--openssl PATH] [--starttls PROTOCOL]
+
+=head1 OPTIONS
+
+=over
+
+=item B<--address> I<address>
+
+Address (host name or IP address) to get the certificate to check from.
+Either this or B<--file> must be specified.
+
+=item B<--file> I<path>
+
+File containing a certificate to check the expiration of. Either this or
+B<--address> must be specified.
+
+=item B<--hostname> I<name>
+
+Host name to specify to the remote server via TLS SNI.
+
+=item B<common-name> I<name>
+
+Confirm the certificate has the expected common name. (Note this doesn't
+handle subjectAltNames and also does not do certificate verification.)
+
+=item B<warn> I<days>
+
+Exit with warning status if certificate expires in I<days> days or fewer.
+
+=item B<crit> I<days>
+
+Exit with critical status if certificate expires in I<days> days or fewer.
+
+=item B<starttls> I<protocol>
+
+Use I<protocol>'s version of STARTTLS to start the TLS connection. This
+must be a protocol supported by OpenSSL's s_client; see
+L<s_client(1ssl)>. As of 1.1.0h, supported protocol include C<smtp>,
+C<pop3>, C<imap>, C<ftp>, C<xmpp>, C<xmpp-server>, and C<irc>.
+
+=item B<openssl> I<path>
+
+Specify the full path to the OpenSSL command-line program. Default is F</usr/bin/openssl>
+
+=back
+
+=cut
+
 sub parseArguments {
+	my $want_help = 0;
 	GetOptions (
 		'address=s' => \$ARG_ADDRESS,
 		'port=s' => \$ARG_PORT,
@@ -251,3 +308,41 @@ sub extractCommonName {
 		exitUnknown("No common name given");
 	}
 }
+
+=head1 CAVEATS
+
+Certificates are not verified, e.g., a certificate signed by an unknown
+certificate authority will be accepted.
+
+=head1 BUGS
+
+There is no way currently to verify subjectAltNames contain the expected
+value(s).
+
+Bug tracker:
+L<https://github.com/vlcty/tls_certificate_expiration_check/issues>.
+
+=head1 AUTHORS
+
+Originally written by Josef 'veloc1ty' Stautner (L<hello@veloc1ty.de>) with
+improvements by Jonas Palm and Anthony DeRobertis (L<anthony@derobert.net>).
+
+Please report any bugs, suggestions, etc. via the issue tracker at
+L<https://github.com/vlcty/tls_certificate_expiration_check/issues>.
+
+=head1 LICENSE
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+=cut

--- a/check_tls_certificate_expiration
+++ b/check_tls_certificate_expiration
@@ -32,6 +32,7 @@ our $ARG_HOSTNAME = ''; # Only used for HTTP SNI
 our $ARG_PORT = 443;
 our $ARG_OPENSSL = '/usr/bin/openssl';
 our $ARG_STARTTLS = '';
+our $ARG_XMPPHOST = '';
 
 # Argument for file check
 our $ARG_FILE = '';
@@ -95,7 +96,7 @@ sub decideExitCode {
 
 =head1 SYNOPSIS
 
-check_tls_certificate_expiration --address ADDRESS|--file FILE [--port PORT] [--hostname SNI_HOSTNAME] [--common-name NAME] [--warn DAYS] [--crit DAYS] [--openssl PATH] [--starttls PROTOCOL]
+check_tls_certificate_expiration --address ADDRESS|--file FILE [--port PORT] [--hostname SNI_HOSTNAME] [--common-name NAME] [--warn DAYS] [--crit DAYS] [--openssl PATH] [--starttls PROTOCOL] [--xmpphost HOST]
 
 =head1 OPTIONS
 
@@ -135,6 +136,12 @@ must be a protocol supported by OpenSSL's s_client; see
 L<s_client(1ssl)>. As of 1.1.0h, supported protocol include C<smtp>,
 C<pop3>, C<imap>, C<ftp>, C<xmpp>, C<xmpp-server>, and C<irc>.
 
+=item B<xmpphost> I<host>
+
+XMPP's STARTTLS requires sending the desired XMPP server name to the
+server. Often this is different than the host name we're connecting to
+(due to XMPP's use of SRV records).
+
 =item B<openssl> I<path>
 
 Specify the full path to the OpenSSL command-line program. Default is F</usr/bin/openssl>
@@ -154,7 +161,8 @@ sub parseArguments {
 		'warn=i' => \$ARG_WARNING_DAYS,
 		'crit=i' => \$ARG_CRITICAL_DAYS,
 		'openssl=s' => \$ARG_OPENSSL,
-		'starttls=s' => \$ARG_STARTTLS
+		'starttls=s' => \$ARG_STARTTLS,
+		'xmpphost=s' => \$ARG_XMPPHOST,
 	);
 
 	validateArguments();
@@ -251,14 +259,22 @@ sub retrieveCertificate {
 			$starttlsPart = sprintf("-starttls %s", $ARG_STARTTLS);
 		}
 
+		# Check if we have an XMPP hostname
+		my $xmpphostPart = '';
+
+		if ( length($ARG_XMPPHOST) != 0 ) {
+			$xmpphostPart = sprintf("-xmpphost %s", $ARG_XMPPHOST);
+		}
+
 		# Build command
 		my $command = sprintf(
-			"echo \"\" | %s s_client -connect %s:%d %s %s 2> /dev/null | %s x509 2> /dev/null",
+			"echo \"\" | %s s_client -connect %s:%d %s %s %s 2> /dev/null | %s x509 2> /dev/null",
 			$ARG_OPENSSL,
 			$ARG_ADDRESS,
 			$ARG_PORT,
 			$starttlsPart,
 			$sniPart,
+			$xmpphostPart,
 			$ARG_OPENSSL
 			);
 


### PR DESCRIPTION
XMPP servers require the remote end to specify the XMPP server/service they expect to talk to in order to do a STARTTLS request. Since XMPP uses SRV records, the service name is often different than the server name we're connecting to.

This includes my other pull request to add POD and --help, because, because, well, it depends on it.