### PR TITLE
Security/fix command injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ The following applications and modules are needed:
 - openssl
 - Perl module "Crypt::OpenSSL::X509"
 - Perl module "Date::Calc"
+- Perl module "IPC::Run3"
 
 If you are on a Debian/Ubuntu based machine you can install the needed perl modules via apt:
 
-```apt-get install libdate-calc-perl libcrypt-openssl-x509-perl```
+```apt-get install libdate-calc-perl libcrypt-openssl-x509-perl libipc-run3-perl```
 
 Another way is to fetch it over CPAN. Your choice!
 

--- a/check_tls_certificate_expiration
+++ b/check_tls_certificate_expiration
@@ -21,6 +21,7 @@ use warnings;
 use Getopt::Long qw(:config auto_help);
 use Date::Calc qw(Delta_Days Parse_Date Today);
 use Crypt::OpenSSL::X509;
+use IPC::Run3 qw(run3);
 
 # Basic Arguments
 our $ARG_WARNING_DAYS = 21;
@@ -244,41 +245,24 @@ sub retrieveCertificate {
 	if ( length($ARG_FILE) == 0 ) {
 		# Network mode
 		# Fetch certificate and return it as a string
+		my @cmd
+			= ($ARG_OPENSSL, 's_client', '-connect', "$ARG_ADDRESS:$ARG_PORT");
 
-		# Check if we have to set SNI
-		my $sniPart = '';
+		push @cmd, (-servername => $ARG_HOSTNAME) if '' ne $ARG_HOSTNAME;
+		push @cmd, (-starttls   => $ARG_STARTTLS) if '' ne $ARG_STARTTLS;
+		push @cmd, (-xmpphost   => $ARG_XMPPHOST) if '' ne $ARG_XMPPHOST;
 
-		if ( length($ARG_HOSTNAME) != 0 ) {
-			$sniPart = sprintf("-servername %s", $ARG_HOSTNAME);
-		}
+		my $out;
+		run3 \@cmd, \undef, \$out, \undef;
 
-		# Check if we have to set starttls protocol
-		my $starttlsPart = '';
-
-		if ( length($ARG_STARTTLS) != 0 ) {
-			$starttlsPart = sprintf("-starttls %s", $ARG_STARTTLS);
-		}
-
-		# Check if we have an XMPP hostname
-		my $xmpphostPart = '';
-
-		if ( length($ARG_XMPPHOST) != 0 ) {
-			$xmpphostPart = sprintf("-xmpphost %s", $ARG_XMPPHOST);
-		}
-
-		# Build command
-		my $command = sprintf(
-			"echo \"\" | %s s_client -connect %s:%d %s %s %s 2> /dev/null | %s x509 2> /dev/null",
-			$ARG_OPENSSL,
-			$ARG_ADDRESS,
-			$ARG_PORT,
-			$starttlsPart,
-			$sniPart,
-			$xmpphostPart,
-			$ARG_OPENSSL
-			);
-
-		$certificate = `$command`;
+		# This seems superfluous; Crypt::OpenSSL::X509 will happily pull
+		# the cert out itself. But the original version pulled it out,
+		# so continuing to do so in case there was a reason.
+		$out =~ /(
+			^-{3,}BEGIN\ CERTIFICATE-{3,}\n
+			.+\n
+			-{3,}END\ CERTIFICATE-{3,}$)/msx;
+		$certificate = $1 // '';
 	}
 	else {
 		# File mode

--- a/check_tls_certificate_expiration
+++ b/check_tls_certificate_expiration
@@ -18,7 +18,7 @@
 
 use strict;
 use warnings;
-use Getopt::Long;
+use Getopt::Long qw(:config auto_help);
 use Date::Calc qw(Delta_Days Parse_Date Today);
 use Crypt::OpenSSL::X509;
 
@@ -36,6 +36,12 @@ our $ARG_STARTTLS = '';
 # Argument for file check
 our $ARG_FILE = '';
 our $ARG_COMMON_NAME = '';
+
+=head1 NAME
+
+check_tls_certificate_expiration - check if a TLS certificate is about to expire
+
+=cut
 
 main();
 
@@ -87,7 +93,58 @@ sub decideExitCode {
 	}
 }
 
+=head1 SYNOPSIS
+
+check_tls_certificate_expiration --address ADDRESS|--file FILE [--port PORT] [--hostname SNI_HOSTNAME] [--common-name NAME] [--warn DAYS] [--crit DAYS] [--openssl PATH] [--starttls PROTOCOL]
+
+=head1 OPTIONS
+
+=over
+
+=item B<--address> I<address>
+
+Address (host name or IP address) to get the certificate to check from.
+Either this or B<--file> must be specified.
+
+=item B<--file> I<path>
+
+File containing a certificate to check the expiration of. Either this or
+B<--address> must be specified.
+
+=item B<--hostname> I<name>
+
+Host name to specify to the remote server via TLS SNI.
+
+=item B<common-name> I<name>
+
+Confirm the certificate has the expected common name. (Note this doesn't
+handle subjectAltNames and also does not do certificate verification.)
+
+=item B<warn> I<days>
+
+Exit with warning status if certificate expires in I<days> days or fewer.
+
+=item B<crit> I<days>
+
+Exit with critical status if certificate expires in I<days> days or fewer.
+
+=item B<starttls> I<protocol>
+
+Use I<protocol>'s version of STARTTLS to start the TLS connection. This
+must be a protocol supported by OpenSSL's s_client; see
+L<s_client(1ssl)>. As of 1.1.0h, supported protocol include C<smtp>,
+C<pop3>, C<imap>, C<ftp>, C<xmpp>, C<xmpp-server>, and C<irc>.
+
+=item B<openssl> I<path>
+
+Specify the full path to the OpenSSL command-line program. Default is F</usr/bin/openssl>
+
+=back
+
+=cut
+
 sub parseArguments {
+	my $want_help = 0;
 	GetOptions (
 		'address=s' => \$ARG_ADDRESS,
 		'port=s' => \$ARG_PORT,
@@ -251,3 +308,41 @@ sub extractCommonName {
 		exitUnknown("No common name given");
 	}
 }
+
+=head1 CAVEATS
+
+Certificates are not verified, e.g., a certificate signed by an unknown
+certificate authority will be accepted.
+
+=head1 BUGS
+
+There is no way currently to verify subjectAltNames contain the expected
+value(s).
+
+Bug tracker:
+L<https://github.com/vlcty/tls_certificate_expiration_check/issues>.
+
+=head1 AUTHORS
+
+Originally written by Josef 'veloc1ty' Stautner (L<hello@veloc1ty.de>) with
+improvements by Jonas Palm and Anthony DeRobertis (L<anthony@derobert.net>).
+
+Please report any bugs, suggestions, etc. via the issue tracker at
+L<https://github.com/vlcty/tls_certificate_expiration_check/issues>.
+
+=head1 LICENSE
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+=cut

--- a/check_tls_certificate_expiration
+++ b/check_tls_certificate_expiration
@@ -32,6 +32,7 @@ our $ARG_HOSTNAME = ''; # Only used for HTTP SNI
 our $ARG_PORT = 443;
 our $ARG_OPENSSL = '/usr/bin/openssl';
 our $ARG_STARTTLS = '';
+our $ARG_XMPPHOST = '';
 
 # Argument for file check
 our $ARG_FILE = '';
@@ -95,7 +96,7 @@ sub decideExitCode {
 
 =head1 SYNOPSIS
 
-check_tls_certificate_expiration --address ADDRESS|--file FILE [--port PORT] [--hostname SNI_HOSTNAME] [--common-name NAME] [--warn DAYS] [--crit DAYS] [--openssl PATH] [--starttls PROTOCOL]
+check_tls_certificate_expiration --address ADDRESS|--file FILE [--port PORT] [--hostname SNI_HOSTNAME] [--common-name NAME] [--warn DAYS] [--crit DAYS] [--openssl PATH] [--starttls PROTOCOL] [--xmpphost HOST]
 
 =head1 OPTIONS
 
@@ -135,6 +136,12 @@ must be a protocol supported by OpenSSL's s_client; see
 L<s_client(1ssl)>. As of 1.1.0h, supported protocol include C<smtp>,
 C<pop3>, C<imap>, C<ftp>, C<xmpp>, C<xmpp-server>, and C<irc>.
 
+=item B<xmpphost> I<host>
+
+XMPP's STARTTLS requires sending the desired XMPP server name to the
+server. Often this is different than the host name we're connecting to
+(due to XMPP's use of SRV records).
+
 =item B<openssl> I<path>
 
 Specify the full path to the OpenSSL command-line program. Default is F</usr/bin/openssl>
@@ -154,7 +161,8 @@ sub parseArguments {
 		'warn=i' => \$ARG_WARNING_DAYS,
 		'crit=i' => \$ARG_CRITICAL_DAYS,
 		'openssl=s' => \$ARG_OPENSSL,
-		'starttls=s' => \$ARG_STARTTLS
+		'starttls=s' => \$ARG_STARTTLS,
+		'xmpphost=s' => \$ARG_XMPPHOST,
 	);
 
 	validateArguments();
@@ -251,14 +259,22 @@ sub retrieveCertificate {
 			$starttlsPart = sprintf("-starttls %s", $ARG_STARTTLS);
 		}
 
+		# Check if we have an XMPP hostname
+		my $xmpphostPart = '';
+
+		if ( length($ARG_XMPPHOST) != 0 ) {
+			$xmpphostPart = sprintf("-xmpphost %s", $ARG_XMPPHOST);
+		}
+
 		# Build command
 		my $command = sprintf(
-			"echo \"\" | %s s_client -connect %s:%d %s %s 2> /dev/null | %s x509 2> /dev/null",
+			"echo \"\" | %s s_client -connect %s:%d %s %s %s 2> /dev/null | %s x509 2> /dev/null",
 			$ARG_OPENSSL,
 			$ARG_ADDRESS,
 			$ARG_PORT,
 			$starttlsPart,
 			$sniPart,
+			$xmpphostPart,
 			$ARG_OPENSSL
 			);
 


### PR DESCRIPTION
Do not pass unescaped stuff to shell.
    
Previously, all the arguments were spewed back to the shell via perl's backtick operator — and without any escaping, or even quoting it. That is a security issue waiting to happen. 

This changes it to avoid the shell entirely. It's easiest to use a module (instead of dealing with the moving file descriptors around then the pipe form of open); I picked IPC::Run3 which is relatively lightweight. Since that rules out building a shell pipeline, could no longer use "openssl x509" to extract just the cert; instead use a regexp.

Note extracting the cert doesn't appear to be required, but not removing it as possibly other versions of the module need it. I presume it was there for a reason.

(Note: Seems to include previous pull requests, too.)
